### PR TITLE
feat: add multi-graph shared-context inference node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for package qrb_ros_nn_inference
 
+## 2.3.0 (2026-07-15)
+- add multi-graph shared-context inference node (QrbRosSharedInferenceNode)
+- Contributors👉 Sam Freund
+
 ## 2.2.0 (2026-05-18)
 - add HTP performance infrastructure initialization for binary model inference
 - support QNN_HTP_NO_PERF env var to opt out of performance init

--- a/README.md
+++ b/README.md
@@ -90,6 +90,65 @@
   </tr>
 </table>
 
+#### `QrbRosSharedInferenceNode`
+
+`QrbRosSharedInferenceNode` loads a single multi-graph QNN context binary once (e.g. two models compiled into one merged/weight-shared context binary) and exposes one input/output tensor topic pair per graph, so the graphs share one backend/device/context instead of each needing its own.
+
+##### ROS node parameters
+
+<table>
+  <tr>
+    <th>Parameter</th>
+    <th>Type</th>
+    <th>Default Value</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>backend_option</td>
+    <td>string</td>
+    <td>""</td>
+    <td>Hardware acceleration option for model inference, vaild values are listed <a href="https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference/blob/main/qrb_inference_manager/Documentation.md#2.1" target="_blank">here</a></td>
+  </tr>
+  <tr>
+    <td>model_path</td>
+    <td>string</td>
+    <td>""</td>
+    <td>Path of the combined multi-graph context binary (.bin) file</td>
+  </tr>
+  <tr>
+    <td>graph_name_0</td>
+    <td>string</td>
+    <td>""</td>
+    <td>Name of the first graph in the context binary, as embedded at compile time</td>
+  </tr>
+  <tr>
+    <td>graph_name_1</td>
+    <td>string</td>
+    <td>""</td>
+    <td>Name of the second graph in the context binary, as embedded at compile time</td>
+  </tr>
+</table>
+
+##### ROS topics
+
+<table>
+  <tr>
+    <th>Topic Name</th>
+    <th>Message Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>qrb_inference_input_tensor_N</td>
+    <td><a href="https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces/blob/main/qrb_ros_tensor_list_msgs/msg/TensorList.msg" target="_blank">TensorList</a></td>
+    <td>Subscribed topic for graph N (N = 0, 1, ...)</td>
+  </tr>
+  <tr>
+    <td>qrb_inference_output_tensor_N</td>
+    <td><a href="https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces/blob/main/qrb_ros_tensor_list_msgs/msg/TensorList.msg" target="_blank">TensorList</a></td>
+    <td>Published topic for graph N (N = 0, 1, ...)</td>
+  </tr>
+</table>
+
 ### 🔹 `qrb_inference_manager` APIs
 
 Please see [qrb_inference_manager APIs](./qrb_inference_manager/Documentation.md).

--- a/qrb_inference_manager/CMakeLists.txt
+++ b/qrb_inference_manager/CMakeLists.txt
@@ -14,6 +14,7 @@ ament_auto_find_build_dependencies()
 
 include_directories(
   include
+  /usr/include/QNN
 )
 
 set(SOURCES

--- a/qrb_inference_manager/include/qnn_inference/qnn_inference.hpp
+++ b/qrb_inference_manager/include/qnn_inference/qnn_inference.hpp
@@ -117,19 +117,54 @@ private:
 class QnnInference : public QrbInference
 {
 public:
+  // Standard constructor: loads model_path, creates its own backend/device/context.
   QnnInference(const std::string & model_path, const std::string & backend_option);
+
+  // Shared-context constructor: borrows an already-created context and interface.
+  // Calls only graphRetrieve for graph_name; does NOT own the context lifetime.
+  // owner_graph_info: tensor metadata from the owner's GraphInfo for this graph (may be nullptr).
+  QnnInference(Qnn_ContextHandle_t shared_context,
+      QnnInterface * shared_interface,
+      const std::string & graph_name,
+      const GraphInfo * owner_graph_info = nullptr);
+
   ~QnnInference();
   StatusCode inference_init() override;
   StatusCode inference_graph_init() override;
   StatusCode inference_execute(const std::vector<uint8_t> & input_tensor_data) override;
+  // Zero-copy variant: passes src pointer directly to QNN without memcpy.
+  StatusCode inference_execute_ptr(const void * src, size_t src_size);
+  // Hybrid: regular input copy + rpcmem output buffers (zero-copy output).
+  StatusCode inference_execute_ptr_dmabuf_out(const void * src, size_t src_size);
   StatusCode inference_execute_dmabuf(int dmabuf_fd, uint32_t dmabuf_size, uint64_t dmabuf_offset);
   const std::vector<OutputTensor> get_output_tensors() override;
+
+  // Accessors used by QrbSharedContextLoader to share context/interface with graph instances.
+  Qnn_ContextHandle_t get_context() const { return context_; }
+  QnnInterface * get_interface() const { return qnn_interface_.get(); }
+
+  // Returns the GraphInfo for the named graph, or nullptr if not found.
+  // Used by QrbSharedContextLoader to copy tensor metadata into shared-context instances.
+  const GraphInfo * get_graph_info_for(const std::string & graph_name) const
+  {
+    if (graphs_info_ == nullptr) return nullptr;
+    for (uint32_t i = 0; i < graphs_count_; ++i) {
+      const GraphInfo & gi = (*graphs_info_)[i];
+      if (gi.graph_name != nullptr && graph_name == gi.graph_name) {
+        return &gi;
+      }
+    }
+    return nullptr;
+  }
 
 private:
   const std::string model_path_;
   const std::string backend_option_;
   const std::string qnn_syslib_path_ = "libQnnSystem.so";
   bool load_model_from_binary = false;
+  // When false this instance borrowed its context from QrbSharedContextLoader
+  // and must not free the context, device, or backend on destruction.
+  bool owned_context_ = true;
   void * backend_lib_handle = nullptr;
   void * sys_lib_handle_ = nullptr;
   void * backend_handle_ = nullptr;
@@ -144,6 +179,14 @@ private:
   bool perf_initialized_ = false;
   std::vector<OutputTensor> output_tensor_;
   std::unique_ptr<QnnInterface> qnn_interface_{ nullptr };
+  // When owned_context_ is false, this holds the borrowed interface pointer (not owned).
+  QnnInterface * borrowed_interface_{ nullptr };
+
+  // Returns the active interface regardless of ownership mode.
+  QnnInterface * iface() const
+  {
+    return owned_context_ ? qnn_interface_.get() : borrowed_interface_;
+  }
 
   StatusCode initialize_backend();
   StatusCode create_device();
@@ -162,13 +205,15 @@ private:
   std::tuple<std::shared_ptr<uint8_t[]>, uint64_t> read_binary_model();
   StatusCode get_and_set_graph_info_from_binary(const std::shared_ptr<uint8_t[]> model_buf,
       const uint64_t model_buf_size);
-  template <typename T>
-  StatusCode copy_graph_info(T graph_info_from_binary);
+  // GraphInfoMember selects which versioned member (graphInfoV1/V2/V3) of
+  // QnnSystemContext_GraphInfo_t to read from for a given binary-info version.
+  template <auto GraphInfoMember>
+  StatusCode copy_graph_info(const QnnSystemContext_GraphInfo_t * graphs_array);
   StatusCode set_up_graph_info(const QnnSystemContext_BinaryInfo_t * binary_info);
   StatusCode create_context_from_binary(const std::shared_ptr<uint8_t[]> model_buf,
       const uint64_t model_buf_size);
 
-  // DMA buffer pool: cached handles for zero-overhead frame-to-frame reuse
+  // DMA buffer pool: cached handles for zero-overhead frame-to-frame reuse (dmabuf path)
   int cached_input_fd_{ -1 };
   Qnn_MemHandle_t cached_input_handle_{ nullptr };
   std::vector<std::shared_ptr<RpcMemManager>> cached_output_buffers_;

--- a/qrb_inference_manager/include/qnn_inference/qnn_inference_impl.hpp
+++ b/qrb_inference_manager/include/qnn_inference/qnn_inference_impl.hpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <numeric>
 #include <vector>
 
@@ -119,6 +120,9 @@ public:
       const uint32_t tensor_cnt,
       const Qnn_Tensor_t * tensor_src);
   StatusCode write_input_tensors(const std::vector<uint8_t> & input_data);
+  // Zero-copy variant: points ClientBuffer.data directly at src without memcpy.
+  // src must remain valid until graphExecute returns.
+  StatusCode write_input_tensors_ptr(const void * src, size_t src_size);
   std::vector<OutputTensor> read_output_tensors(const uint32_t number_of_outputs);
   void free_qnn_tensors(Qnn_Tensor_t * tensors, uint32_t tensors_cnt);
   StatusCode tensor_info_deep_copy(Qnn_Tensor_t * dst, const Qnn_Tensor_t * src);

--- a/qrb_inference_manager/include/qrb_inference_manager.hpp
+++ b/qrb_inference_manager/include/qrb_inference_manager.hpp
@@ -4,6 +4,10 @@
 #ifndef QRB_INFERENCE_MANAGER_QRB_INFERENCE_MANAGER_HPP_
 #define QRB_INFERENCE_MANAGER_QRB_INFERENCE_MANAGER_HPP_
 
+#include <memory>
+#include <string>
+
+#include "qnn_inference/qnn_inference.hpp"
 #include "qrb_inference.hpp"
 
 namespace qrb::inference_mgr
@@ -12,15 +16,46 @@ namespace qrb::inference_mgr
 class QrbInferenceManager
 {
 public:
+  // Standard constructor: loads model_path independently.
   QrbInferenceManager(const std::string & model_path, const std::string & backend_option = "");
+
+  // Shared-context constructor: borrows context and interface from QrbSharedContextLoader.
+  // owner_graph_info: tensor metadata from the owner for this graph (for I/O buffer setup).
+  QrbInferenceManager(Qnn_ContextHandle_t shared_context,
+      QnnInterface * shared_interface,
+      const std::string & graph_name,
+      const GraphInfo * owner_graph_info = nullptr);
+
   ~QrbInferenceManager() = default;
   bool inference_execute(const std::vector<uint8_t> & input_tensor_data);
+  // Zero-copy variant: passes src pointer directly to QNN without memcpy.
+  bool inference_execute_ptr(const void * src, size_t src_size);
+  // Hybrid: regular input copy + rpcmem output buffers (zero-copy output side).
+  bool inference_execute_ptr_dmabuf_out(const void * src, size_t src_size);
   bool inference_execute_dmabuf(int dmabuf_fd, uint32_t dmabuf_size, uint64_t dmabuf_offset = 0);
   std::vector<OutputTensor> get_output_tensors();
 
 private:
   std::unique_ptr<QrbInference> qrb_inference_{ nullptr };
 };  // class QrbInferenceManager
+
+// Loads a multi-graph QNN context binary once and vends per-graph QrbInferenceManager instances.
+// Owns the QnnContext, QnnDevice, and QnnBackend for the lifetime of all vended managers.
+// Must outlive all managers created via make_graph_manager().
+class QrbSharedContextLoader
+{
+public:
+  QrbSharedContextLoader(const std::string & model_path, const std::string & backend_option);
+  ~QrbSharedContextLoader() = default;
+
+  // Returns a QrbInferenceManager that executes the named graph within the shared context.
+  // Throws std::logic_error if graph_name is not found or init fails.
+  std::unique_ptr<QrbInferenceManager> make_graph_manager(const std::string & graph_name);
+
+private:
+  // Owns the context, device, and backend. Never used for inference — only for lifetime.
+  std::unique_ptr<QnnInference> owner_;
+};  // class QrbSharedContextLoader
 
 }  // namespace qrb::inference_mgr
 

--- a/qrb_inference_manager/src/qnn_inference/qnn_inference.cpp
+++ b/qrb_inference_manager/src/qnn_inference/qnn_inference.cpp
@@ -23,31 +23,114 @@ QnnInference::QnnInference(const std::string & model_path, const std::string & b
   }
 }
 
+QnnInference::QnnInference(Qnn_ContextHandle_t shared_context,
+    QnnInterface * shared_interface,
+    const std::string & graph_name,
+    const GraphInfo * owner_graph_info)
+  : owned_context_(false), borrowed_interface_(shared_interface)
+{
+  // Borrow the already-created context and interface — do not take ownership.
+  context_ = shared_context;
+
+  QRB_INFO("Retrieving shared-context graph: '", graph_name, "'");
+
+  // Allocate graphs_info_ as a pointer to a contiguous GraphInfo array (same layout as owner).
+  graphs_info_ = (GraphInfo **)calloc(1, sizeof(GraphInfo *));
+  if (graphs_info_ == nullptr) {
+    QRB_ERROR("Failed to allocate graphs_info_ for shared-context graph: ", graph_name);
+    return;
+  }
+  *graphs_info_ = (GraphInfo *)calloc(1, sizeof(GraphInfo));
+  if (*graphs_info_ == nullptr) {
+    QRB_ERROR("Failed to allocate GraphInfo for shared-context graph: ", graph_name);
+    free(graphs_info_);
+    graphs_info_ = nullptr;
+    return;
+  }
+
+  GraphInfo & gi = (*graphs_info_)[0];
+
+  auto rc = borrowed_interface_->interface_.graphRetrieve(
+      context_, graph_name.c_str(), &(gi.graph));
+  if (QNN_SUCCESS != rc) {
+    QRB_ERROR("graphRetrieve failed for graph '", graph_name, "' rc=", rc);
+    return;
+  }
+  graphs_count_ = 1;
+
+  // Copy graph name.
+  gi.graph_name = (char *)malloc(graph_name.size() + 1);
+  if (gi.graph_name != nullptr) {
+    memcpy(gi.graph_name, graph_name.c_str(), graph_name.size() + 1);
+  }
+
+  // Copy tensor metadata from the owner's GraphInfo so inference_execute can set up I/O buffers.
+  if (owner_graph_info != nullptr) {
+    QnnTensor tensor_ops;
+    gi.num_of_input_tensors = owner_graph_info->num_of_input_tensors;
+    if (gi.num_of_input_tensors > 0 && owner_graph_info->input_tensors != nullptr) {
+      if (StatusCode::SUCCESS != tensor_ops.setup_tensors(
+              gi.input_tensors, gi.num_of_input_tensors, owner_graph_info->input_tensors)) {
+        QRB_ERROR("Failed to copy input tensor metadata for graph: ", graph_name);
+        graphs_count_ = 0;
+        return;
+      }
+    }
+    gi.num_of_output_tensors = owner_graph_info->num_of_output_tensors;
+    if (gi.num_of_output_tensors > 0 && owner_graph_info->output_tensors != nullptr) {
+      if (StatusCode::SUCCESS != tensor_ops.setup_tensors(
+              gi.output_tensors, gi.num_of_output_tensors, owner_graph_info->output_tensors)) {
+        QRB_ERROR("Failed to copy output tensor metadata for graph: ", graph_name);
+        graphs_count_ = 0;
+        return;
+      }
+    }
+    QRB_INFO("Shared-context graph '", graph_name, "': ",
+        gi.num_of_input_tensors, " input(s), ", gi.num_of_output_tensors, " output(s)");
+  } else {
+    QRB_WARNING("No owner_graph_info provided for '", graph_name,
+        "' — tensor metadata unavailable, inference may fail");
+  }
+
+  QRB_INFO("Shared-context graph '", graph_name, "' retrieved successfully");
+}
+
 QnnInference::~QnnInference()
 {
   free_graphs_info();
-  free_context();
-  free_device();
-  free_backend();
+  if (owned_context_) {
+    free_context();
+    free_device();
+    free_backend();
 
-  if (backend_lib_handle) {
-    ::dlclose(backend_lib_handle);
-    backend_lib_handle = nullptr;
-  }
+    if (backend_lib_handle) {
+      ::dlclose(backend_lib_handle);
+      backend_lib_handle = nullptr;
+    }
 
-  if (model_handle_) {
-    ::dlclose(model_handle_);
-    model_handle_ = nullptr;
-  }
+    if (model_handle_) {
+      ::dlclose(model_handle_);
+      model_handle_ = nullptr;
+    }
 
-  if (sys_lib_handle_) {
-    ::dlclose(sys_lib_handle_);
-    sys_lib_handle_ = nullptr;
+    if (sys_lib_handle_) {
+      ::dlclose(sys_lib_handle_);
+      sys_lib_handle_ = nullptr;
+    }
+  } else {
+    // Borrowed interface — do not delete, just null the pointer.
+    borrowed_interface_ = nullptr;
+    context_ = nullptr;
   }
 }
 
 StatusCode QnnInference::inference_init()
 {
+  // Shared-context instances have no backend/device to initialize.
+  if (!owned_context_) {
+    return StatusCode::SUCCESS;
+  }
+
   if (initialize_backend() != StatusCode::SUCCESS) {
     return StatusCode::FAILURE;
   }
@@ -61,6 +144,11 @@ StatusCode QnnInference::inference_init()
 
 StatusCode QnnInference::inference_graph_init()
 {
+  // Shared-context instances already have their graph retrieved in the constructor.
+  if (!owned_context_) {
+    return graphs_count_ > 0 ? StatusCode::SUCCESS : StatusCode::FAILURE;
+  }
+
   if (true == load_model_from_binary) {
     if (init_graph_from_binary() != StatusCode::SUCCESS) {
       return StatusCode::FAILURE;
@@ -101,6 +189,15 @@ StatusCode QnnInference::inference_execute(const std::vector<uint8_t> & input_te
     QRB_ERROR("Input tensor is NULL!");
     return StatusCode::FAILURE;
   }
+  return inference_execute_ptr(input_tensor_data.data(), input_tensor_data.size());
+}
+
+StatusCode QnnInference::inference_execute_ptr(const void * src, size_t src_size)
+{
+  if (src == nullptr || src_size == 0) {
+    QRB_ERROR("Input tensor pointer is NULL or size is 0!");
+    return StatusCode::FAILURE;
+  }
 
   for (uint32_t i = 0; i < graphs_count_; i++) {
     const auto & graphs_info = (*(graphs_info_))[i];
@@ -120,12 +217,12 @@ StatusCode QnnInference::inference_execute(const std::vector<uint8_t> & input_te
       return StatusCode::FAILURE;
     }
 
-    if (StatusCode::SUCCESS != io_tensors.write_input_tensors(input_tensor_data)) {
+    if (StatusCode::SUCCESS != io_tensors.write_input_tensors_ptr(src, src_size)) {
       QRB_ERROR("Write QNN input tensors failed!");
       return StatusCode::FAILURE;
     }
 
-    auto graph_exec_rc = this->qnn_interface_->interface_.graphExecute(graphs_info.graph,
+    auto graph_exec_rc = this->iface()->interface_.graphExecute(graphs_info.graph,
         io_tensors.inputs_, io_tensors.num_of_input_tensors_, io_tensors.outputs_,
         io_tensors.num_of_output_tensors_, nullptr, nullptr);
     if (QNN_GRAPH_NO_ERROR != graph_exec_rc) {
@@ -142,6 +239,14 @@ StatusCode QnnInference::inference_execute(const std::vector<uint8_t> & input_te
 #endif
   }
   return StatusCode::SUCCESS;
+}
+
+StatusCode QnnInference::inference_execute_ptr_dmabuf_out(const void * src, size_t src_size)
+{
+  // NOTE: QNN HTP requires both input and output to use the same memory path.
+  // Mixing ClientBuffer input with MEMHANDLE output causes graphExecute to crash.
+  // This method is kept for API completeness but falls back to regular execute.
+  return inference_execute_ptr(src, src_size);
 }
 
 StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
@@ -175,7 +280,7 @@ StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
     if (cached_input_fd_ != dmabuf_fd || cached_input_handle_ == nullptr) {
       // Input fd changed or first frame: (de)register
       if (cached_input_handle_ != nullptr) {
-        qnn_interface_->interface_.memDeRegister(&cached_input_handle_, 1u);
+        iface()->interface_.memDeRegister(&cached_input_handle_, 1u);
         cached_input_handle_ = nullptr;
       }
 
@@ -187,11 +292,11 @@ StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
         input_mem_desc.memType = QNN_MEM_TYPE_ION;
         input_mem_desc.ionInfo.fd = dmabuf_fd;
 
-        auto rc = qnn_interface_->interface_.memRegister(
+        auto rc = iface()->interface_.memRegister(
             context_, &input_mem_desc, 1u, &cached_input_handle_);
         if (QNN_SUCCESS != rc) {
           const char * err_msg = nullptr;
-          qnn_interface_->interface_.errorGetMessage(rc, &err_msg);
+          iface()->interface_.errorGetMessage(rc, &err_msg);
           QRB_ERROR("memRegister(input) failed: ", (err_msg ? err_msg : "unknown"));
           cached_input_handle_ = nullptr;
           return StatusCode::FAILURE;
@@ -211,11 +316,11 @@ StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
         htp_mem_desc.sharedBufferConfig = htp_shared_buf_config;
         input_mem_desc.customInfo = &htp_mem_desc;
 
-        auto rc = qnn_interface_->interface_.memRegister(
+        auto rc = iface()->interface_.memRegister(
             context_, &input_mem_desc, 1u, &cached_input_handle_);
         if (QNN_SUCCESS != rc) {
           const char * err_msg = nullptr;
-          qnn_interface_->interface_.errorGetMessage(rc, &err_msg);
+          iface()->interface_.errorGetMessage(rc, &err_msg);
           QRB_ERROR("memRegister(input) failed: ", (err_msg ? err_msg : "unknown"));
           cached_input_handle_ = nullptr;
           return StatusCode::FAILURE;
@@ -268,10 +373,10 @@ StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
 
         Qnn_MemHandle_t out_mem_handle = nullptr;
         auto out_rc =
-            qnn_interface_->interface_.memRegister(context_, &out_mem_desc, 1u, &out_mem_handle);
+            iface()->interface_.memRegister(context_, &out_mem_desc, 1u, &out_mem_handle);
         if (QNN_SUCCESS != out_rc) {
           const char * err_msg = nullptr;
-          qnn_interface_->interface_.errorGetMessage(out_rc, &err_msg);
+          iface()->interface_.errorGetMessage(out_rc, &err_msg);
           QRB_ERROR("memRegister(output) failed: ", (err_msg ? err_msg : "unknown"));
           return StatusCode::FAILURE;
         }
@@ -294,7 +399,7 @@ StatusCode QnnInference::inference_execute_dmabuf(int dmabuf_fd,
     }
 
     // EXECUTE: No register/deregister overhead
-    auto exec_rc = qnn_interface_->interface_.graphExecute(graph_info.graph, io_tensors.inputs_,
+    auto exec_rc = iface()->interface_.graphExecute(graph_info.graph, io_tensors.inputs_,
         io_tensors.num_of_input_tensors_, io_tensors.outputs_, io_tensors.num_of_output_tensors_,
         nullptr, nullptr);
 
@@ -445,21 +550,26 @@ void QnnInference::free_graphs_info()
     }
   };
 
-  for (uint32_t i = 0; i < graphs_count_; i++) {
-    auto & graph_info = graphs_info_[i];
-    check_and_free(graph_info->graph_name);
+  if (*graphs_info_ != nullptr) {
+    for (uint32_t i = 0; i < graphs_count_; i++) {
+      GraphInfo & graph_info = (*graphs_info_)[i];
+      check_and_free(graph_info.graph_name);
 
-    QnnTensor tensor_ops;
-    tensor_ops.free_qnn_tensors(graph_info->input_tensors, graph_info->num_of_input_tensors);
-    tensor_ops.free_qnn_tensors(graph_info->output_tensors, graph_info->num_of_output_tensors);
+      QnnTensor tensor_ops;
+      tensor_ops.free_qnn_tensors(graph_info.input_tensors, graph_info.num_of_input_tensors);
+      tensor_ops.free_qnn_tensors(graph_info.output_tensors, graph_info.num_of_output_tensors);
+    }
+    check_and_free(*graphs_info_);
   }
 
-  check_and_free(*graphs_info_);
   check_and_free(graphs_info_);
 }
 
 void QnnInference::free_context()
 {
+  if (!owned_context_) {
+    return;
+  }
   if (QNN_CONTEXT_NO_ERROR != qnn_interface_->interface_.contextFree(context_, nullptr)) {
     QRB_ERROR("Failed to free context!");
   }
@@ -469,6 +579,9 @@ void QnnInference::free_context()
 
 void QnnInference::free_device()
 {
+  if (!owned_context_) {
+    return;
+  }
   if (perf_initialized_ && perf_infra_.destroyPowerConfigId != nullptr) {
     perf_infra_.destroyPowerConfigId(power_config_id_);
     perf_initialized_ = false;
@@ -488,6 +601,9 @@ void QnnInference::free_device()
 
 void QnnInference::free_backend()
 {
+  if (!owned_context_) {
+    return;
+  }
   if (qnn_interface_->interface_.backendFree != nullptr) {
     if (QNN_BACKEND_NO_ERROR != qnn_interface_->interface_.backendFree(backend_handle_)) {
       QRB_ERROR("Could not free backend!");
@@ -658,65 +774,58 @@ StatusCode QnnInference::get_and_set_graph_info_from_binary(
   return StatusCode::SUCCESS;
 }
 
-template <typename T>
-StatusCode QnnInference::copy_graph_info(T graph_info_from_binary)
+// Helper: allocate and deep-copy tensor metadata from a QNN tensor array.
+static StatusCode set_up_tensors_info(
+    const Qnn_Tensor_t * src, const uint32_t cnt, Qnn_Tensor_t *& dst)
 {
-  graphs_info_ = (GraphInfo **)calloc(graphs_count_, sizeof(GraphInfo *));
+  dst = (Qnn_Tensor_t *)calloc(cnt, sizeof(Qnn_Tensor_t));
+  if (nullptr == dst) {
+    return StatusCode::FAILURE;
+  }
+  QnnTensor tensor_ops;
+  for (size_t j = 0; j < cnt; j++) {
+    dst[j] = QNN_TENSOR_INIT;
+    if (StatusCode::SUCCESS != tensor_ops.tensor_info_deep_copy(&dst[j], &src[j])) {
+      return StatusCode::FAILURE;
+    }
+  }
+  return StatusCode::SUCCESS;
+}
+
+// GraphInfoMember is a pointer-to-member selecting graphInfoV1/V2/V3 out of
+// QnnSystemContext_GraphInfo_t, so the same loop body works for every binary-info version.
+template <auto GraphInfoMember>
+StatusCode QnnInference::copy_graph_info(const QnnSystemContext_GraphInfo_t * graphs_array)
+{
+  // graphs_info_ is GraphInfo** where *graphs_info_ points to a contiguous GraphInfo array.
+  // Allocate the outer pointer and the inner contiguous array.
+  graphs_info_ = (GraphInfo **)calloc(1, sizeof(GraphInfo *));
   if (nullptr == graphs_info_) {
     return StatusCode::FAILURE;
   }
-
-  for (uint32_t i = 0; i < graphs_count_; i++) {
-    auto graph_info_dst = (GraphInfo *)calloc(1, sizeof(GraphInfo));
-    if (nullptr == graph_info_dst) {
-      return StatusCode::FAILURE;
-    }
-
-    graph_info_dst->graph_name =
-        (char *)malloc(sizeof(char) * (strlen(graph_info_from_binary.graphName) + 1));
-    if (nullptr == graph_info_dst->graph_name) {
-      return StatusCode::FAILURE;
-    }
-    memcpy(graph_info_dst->graph_name, graph_info_from_binary.graphName,
-        strlen(graph_info_from_binary.graphName));
-    graph_info_dst->graph_name[strlen(graph_info_from_binary.graphName)] = '\0';
-
-    auto set_up_tensors_info = [](const Qnn_Tensor_t * src, const uint32_t cnt,
-                                   Qnn_Tensor_t *& dst) {
-      dst = (Qnn_Tensor_t *)calloc(cnt, sizeof(Qnn_Tensor_t));
-      if (nullptr == dst) {
-        return StatusCode::FAILURE;
-      }
-
-      QnnTensor tensor_ops;
-
-      for (size_t i = 0; i < cnt; i++) {
-        dst[i] = QNN_TENSOR_INIT;
-        if (StatusCode::SUCCESS != tensor_ops.tensor_info_deep_copy(&dst[i], &src[i])) {
-          return StatusCode::FAILURE;
-        }
-      }
-
-      return StatusCode::SUCCESS;
-    };
-
-    graph_info_dst->num_of_input_tensors = graph_info_from_binary.numGraphInputs;
-    if (StatusCode::SUCCESS != set_up_tensors_info(graph_info_from_binary.graphInputs,
-                                   graph_info_from_binary.numGraphInputs,
-                                   graph_info_dst->input_tensors)) {
-      return StatusCode::FAILURE;
-    }
-
-    graph_info_dst->num_of_output_tensors = graph_info_from_binary.numGraphOutputs;
-    if (StatusCode::SUCCESS != set_up_tensors_info(graph_info_from_binary.graphOutputs,
-                                   graph_info_from_binary.numGraphOutputs,
-                                   graph_info_dst->output_tensors)) {
-      return StatusCode::FAILURE;
-    }
-
-    graphs_info_[i] = graph_info_dst;
+  *graphs_info_ = (GraphInfo *)calloc(graphs_count_, sizeof(GraphInfo));
+  if (nullptr == *graphs_info_) {
+    return StatusCode::FAILURE;
   }
-
+  for (uint32_t i = 0; i < graphs_count_; i++) {
+    GraphInfo & dst = (*graphs_info_)[i];
+    const auto & gi_src = graphs_array[i].*GraphInfoMember;
+    dst.graph_name = (char *)malloc(strlen(gi_src.graphName) + 1);
+    if (nullptr == dst.graph_name) {
+      return StatusCode::FAILURE;
+    }
+    memcpy(dst.graph_name, gi_src.graphName, strlen(gi_src.graphName) + 1);
+    dst.num_of_input_tensors = gi_src.numGraphInputs;
+    if (StatusCode::SUCCESS !=
+        set_up_tensors_info(gi_src.graphInputs, gi_src.numGraphInputs, dst.input_tensors)) {
+      return StatusCode::FAILURE;
+    }
+    dst.num_of_output_tensors = gi_src.numGraphOutputs;
+    if (StatusCode::SUCCESS !=
+        set_up_tensors_info(gi_src.graphOutputs, gi_src.numGraphOutputs, dst.output_tensors)) {
+      return StatusCode::FAILURE;
+    }
+  }
   return StatusCode::SUCCESS;
 }
 
@@ -736,7 +845,10 @@ StatusCode QnnInference::set_up_graph_info(const QnnSystemContext_BinaryInfo_t *
       QRB_INFO("Context binary info (V1): SDK build=", (info.buildId ? info.buildId : "unknown"),
           ", target SoC=", (info.socVersion ? info.socVersion : "unknown"));
       graphs_count_ = info.numGraphs;
-      if (StatusCode::SUCCESS != copy_graph_info(info.graphs->graphInfoV1)) {
+      // Pass the full QnnSystemContext_GraphInfo_t array so copy_graph_info
+      // can stride correctly through all graphs.
+      if (StatusCode::SUCCESS !=
+          copy_graph_info<&QnnSystemContext_GraphInfo_t::graphInfoV1>(info.graphs)) {
         return StatusCode::FAILURE;
       }
       break;
@@ -746,7 +858,8 @@ StatusCode QnnInference::set_up_graph_info(const QnnSystemContext_BinaryInfo_t *
       QRB_INFO("Context binary info (V2): SDK build=", (info.buildId ? info.buildId : "unknown"),
           ", target SoC=", (info.socVersion ? info.socVersion : "unknown"));
       graphs_count_ = info.numGraphs;
-      if (StatusCode::SUCCESS != copy_graph_info(info.graphs->graphInfoV2)) {
+      if (StatusCode::SUCCESS !=
+          copy_graph_info<&QnnSystemContext_GraphInfo_t::graphInfoV2>(info.graphs)) {
         return StatusCode::FAILURE;
       }
       break;
@@ -765,7 +878,8 @@ StatusCode QnnInference::set_up_graph_info(const QnnSystemContext_BinaryInfo_t *
         QRB_INFO("Model is a standard context binary targeting a specific SoC");
       }
       graphs_count_ = info.numGraphs;
-      if (StatusCode::SUCCESS != copy_graph_info(info.graphs->graphInfoV3)) {
+      if (StatusCode::SUCCESS !=
+          copy_graph_info<&QnnSystemContext_GraphInfo_t::graphInfoV3>(info.graphs)) {
         return StatusCode::FAILURE;
       }
       break;
@@ -808,14 +922,14 @@ void QnnInference::log_error_details(Qnn_ErrorHandle_t error_handle)
   }
 
   // Try verbose message first
-  if (qnn_interface_->interface_.errorGetVerboseMessage != nullptr) {
+  if (iface()->interface_.errorGetVerboseMessage != nullptr) {
     const char * verbose_msg = nullptr;
     if (QNN_SUCCESS ==
-        qnn_interface_->interface_.errorGetVerboseMessage(error_handle, &verbose_msg)) {
+        iface()->interface_.errorGetVerboseMessage(error_handle, &verbose_msg)) {
       if (verbose_msg != nullptr) {
         QRB_ERROR("Detailed error info: ", verbose_msg);
-        if (qnn_interface_->interface_.errorFreeVerboseMessage != nullptr) {
-          qnn_interface_->interface_.errorFreeVerboseMessage(verbose_msg);
+        if (iface()->interface_.errorFreeVerboseMessage != nullptr) {
+          iface()->interface_.errorFreeVerboseMessage(verbose_msg);
         }
         return;
       }
@@ -823,9 +937,9 @@ void QnnInference::log_error_details(Qnn_ErrorHandle_t error_handle)
   }
 
   // Fall back to basic error message
-  if (qnn_interface_->interface_.errorGetMessage != nullptr) {
+  if (iface()->interface_.errorGetMessage != nullptr) {
     const char * err_msg = nullptr;
-    if (QNN_SUCCESS == qnn_interface_->interface_.errorGetMessage(error_handle, &err_msg)) {
+    if (QNN_SUCCESS == iface()->interface_.errorGetMessage(error_handle, &err_msg)) {
       if (err_msg != nullptr) {
         QRB_ERROR("Error info: ", err_msg);
       }

--- a/qrb_inference_manager/src/qnn_inference/qnn_inference_impl.cpp
+++ b/qrb_inference_manager/src/qnn_inference/qnn_inference_impl.cpp
@@ -212,11 +212,16 @@ StatusCode QnnTensor::setup_tensors(Qnn_Tensor_t *& tensor,
 /// @return SUCCESS or FAILURE
 StatusCode QnnTensor::write_input_tensors(const std::vector<uint8_t> & input_data)
 {
+  return write_input_tensors_ptr(input_data.data(), input_data.size());
+}
+
+StatusCode QnnTensor::write_input_tensors_ptr(const void * src, size_t src_size)
+{
   if (inputs_ == nullptr) {
     return StatusCode::FAILURE;
   }
 
-  // Calculate total expected size for all input tensors
+  // Calculate total expected size
   size_t total_expected_size = 0;
   for (uint32_t i = 0; i < num_of_input_tensors_; i++) {
     std::vector<size_t> shape;
@@ -226,13 +231,13 @@ StatusCode QnnTensor::write_input_tensors(const std::vector<uint8_t> & input_dat
     total_expected_size += get_tensor_size(&inputs_[i], shape);
   }
 
-  if (total_expected_size != input_data.size()) {
+  if (total_expected_size != src_size) {
     QRB_ERROR("Total size of all input tensors should be ", total_expected_size,
-        " bytes, but receive ", input_data.size(), " bytes");
+        " bytes, but receive ", src_size, " bytes");
     return StatusCode::FAILURE;
   }
 
-  // Fill data into each input tensor
+  // Copy src into the pre-allocated QNN ClientBuffer (must be in accessible memory).
   size_t data_offset = 0;
   for (uint32_t i = 0; i < num_of_input_tensors_; i++) {
     std::vector<size_t> shape;
@@ -247,9 +252,8 @@ StatusCode QnnTensor::write_input_tensors(const std::vector<uint8_t> & input_dat
 
     size_t tensor_size = get_tensor_size(&inputs_[i], shape);
 
-    // Copy data for this tensor
     memcpy(static_cast<char *>(get_tensor_client_buf(&inputs_[i]).data),
-        input_data.data() + data_offset, tensor_size);
+        static_cast<const char *>(src) + data_offset, tensor_size);
 
     data_offset += tensor_size;
   }

--- a/qrb_inference_manager/src/qrb_inference_manager.cpp
+++ b/qrb_inference_manager/src/qrb_inference_manager.cpp
@@ -42,12 +42,60 @@ QrbInferenceManager::QrbInferenceManager(const std::string & model_path,
   }
 }
 
+/**
+ * \brief Shared-context constructor: borrows an already-created QNN context.
+ *        Only the named graph is retrieved; context lifetime is managed externally.
+ * \param shared_context  QNN context handle owned by QrbSharedContextLoader
+ * \param shared_interface  QnnInterface pointer owned by QrbSharedContextLoader
+ * \param graph_name  name of the graph to retrieve from the shared context
+ * \throw std::logic_error if graph retrieval or init fails
+ */
+QrbInferenceManager::QrbInferenceManager(Qnn_ContextHandle_t shared_context,
+    QnnInterface * shared_interface,
+    const std::string & graph_name,
+    const GraphInfo * owner_graph_info)
+{
+  auto inference = std::make_unique<QnnInference>(
+      shared_context, shared_interface, graph_name, owner_graph_info);
+
+  if (inference->inference_init() != StatusCode::SUCCESS) {
+    throw std::logic_error("ERROR: Shared-context inference init fail for graph: " + graph_name);
+  }
+
+  if (inference->inference_graph_init() != StatusCode::SUCCESS) {
+    throw std::logic_error(
+        "ERROR: Shared-context inference graph init fail for graph: " + graph_name);
+  }
+
+  qrb_inference_ = std::move(inference);
+}
+
 bool QrbInferenceManager::inference_execute(const std::vector<uint8_t> & input_tensor_data)
 {
   if (qrb_inference_->inference_execute(input_tensor_data) == StatusCode::SUCCESS) {
     return true;
   }
   return false;
+}
+
+bool QrbInferenceManager::inference_execute_ptr(const void * src, size_t src_size)
+{
+  auto * qnn_inference = dynamic_cast<QnnInference *>(qrb_inference_.get());
+  if (nullptr == qnn_inference) {
+    QRB_ERROR("inference_execute_ptr is only supported by QnnInference.");
+    return false;
+  }
+  return qnn_inference->inference_execute_ptr(src, src_size) == StatusCode::SUCCESS;
+}
+
+bool QrbInferenceManager::inference_execute_ptr_dmabuf_out(const void * src, size_t src_size)
+{
+  auto * qnn_inference = dynamic_cast<QnnInference *>(qrb_inference_.get());
+  if (nullptr == qnn_inference) {
+    QRB_ERROR("inference_execute_ptr_dmabuf_out is only supported by QnnInference.");
+    return false;
+  }
+  return qnn_inference->inference_execute_ptr_dmabuf_out(src, src_size) == StatusCode::SUCCESS;
 }
 
 bool QrbInferenceManager::inference_execute_dmabuf(int dmabuf_fd,
@@ -70,6 +118,51 @@ bool QrbInferenceManager::inference_execute_dmabuf(int dmabuf_fd,
 std::vector<OutputTensor> QrbInferenceManager::get_output_tensors()
 {
   return this->qrb_inference_->get_output_tensors();
+}
+
+// ---------------------------------------------------------------------------
+// QrbSharedContextLoader
+// ---------------------------------------------------------------------------
+
+/**
+ * \brief Load a multi-graph QNN context binary and own the resulting context.
+ *        Use make_graph_manager() to obtain per-graph inference handles.
+ * \param model_path     path to the combined multi-graph .bin file
+ * \param backend_option backend lib (e.g. "/usr/lib/libQnnHtp.so")
+ * \throw std::logic_error if loading or init fails
+ */
+QrbSharedContextLoader::QrbSharedContextLoader(const std::string & model_path,
+    const std::string & backend_option)
+{
+  owner_ = std::make_unique<QnnInference>(model_path, backend_option);
+
+  if (owner_->inference_init() != StatusCode::SUCCESS) {
+    throw std::logic_error("ERROR: QrbSharedContextLoader backend/device init failed");
+  }
+
+  if (owner_->inference_graph_init() != StatusCode::SUCCESS) {
+    throw std::logic_error("ERROR: QrbSharedContextLoader context/graph init failed");
+  }
+
+  QRB_INFO("QrbSharedContextLoader: shared context loaded from ", model_path);
+}
+
+/**
+ * \brief Create a QrbInferenceManager that executes the named graph within the shared context.
+ * \param graph_name  name of the graph as embedded in the context binary
+ * \return unique_ptr to a ready-to-use QrbInferenceManager
+ * \throw std::logic_error if graph_name is not found or init fails
+ */
+std::unique_ptr<QrbInferenceManager> QrbSharedContextLoader::make_graph_manager(
+    const std::string & graph_name)
+{
+  const GraphInfo * gi = owner_->get_graph_info_for(graph_name);
+  if (gi == nullptr) {
+    QRB_WARNING("make_graph_manager: no GraphInfo found for '", graph_name,
+        "' — tensor metadata will be unavailable");
+  }
+  return std::make_unique<QrbInferenceManager>(
+      owner_->get_context(), owner_->get_interface(), graph_name, gi);
 }
 
 }  // namespace qrb::inference_mgr

--- a/qrb_ros_nn_inference/CMakeLists.txt
+++ b/qrb_ros_nn_inference/CMakeLists.txt
@@ -14,13 +14,37 @@ ament_auto_find_build_dependencies()
 
 include_directories(
   ./include
+  /usr/include/QNN
 )
 
-ament_auto_add_library(qrb_ros_inference_node SHARED src/qrb_ros_inference_node.cpp)
+ament_auto_add_library(qrb_ros_inference_node SHARED
+  src/qrb_ros_inference_node.cpp
+  src/qrb_ros_shared_inference_node.cpp)
+
+# Detect whether the installed qrb_ros_tensor_list_msgs Tensor message has dmabuf fields.
+# Older versions (1.0.0) do not; newer versions do.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_INCLUDES ${qrb_ros_tensor_list_msgs_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_FLAGS "-std=c++17")
+check_cxx_source_compiles("
+  #include <qrb_ros_tensor_list_msgs/msg/tensor.hpp>
+  int main() {
+    qrb_ros_tensor_list_msgs::msg::Tensor t;
+    (void)t.dmabuf_fd;
+    return 0;
+  }
+" QRB_TENSOR_HAS_DMABUF_FIELD)
+if(QRB_TENSOR_HAS_DMABUF_FIELD)
+  target_compile_definitions(qrb_ros_inference_node PRIVATE QRB_TENSOR_HAS_DMABUF)
+endif()
 
 rclcpp_components_register_nodes(
   qrb_ros_inference_node
   PLUGIN "qrb_ros::nn_inference::QrbRosInferenceNode")
+
+rclcpp_components_register_nodes(
+  qrb_ros_inference_node
+  PLUGIN "qrb_ros::nn_inference::QrbRosSharedInferenceNode")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/qrb_ros_nn_inference/include/qrb_ros_nn_inference/qrb_ros_shared_inference_node.hpp
+++ b/qrb_ros_nn_inference/include/qrb_ros_nn_inference/qrb_ros_shared_inference_node.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+#ifndef QRB_ROS_SHARED_INFERENCE_NODE_HPP_
+#define QRB_ROS_SHARED_INFERENCE_NODE_HPP_
+
+#include <memory>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "qrb_inference_manager.hpp"
+#include "qrb_ros_tensor_list_msgs/msg/tensor_list.hpp"
+
+namespace qrb_ros::nn_inference
+{
+
+namespace custom_msg = qrb_ros_tensor_list_msgs::msg;
+
+// Loads a single multi-graph QNN context binary and exposes one pub/sub pair per graph.
+// Topics are named qrb_inference_input_tensor_N / qrb_inference_output_tensor_N (N = 0, 1, ...).
+// Parameters:
+//   backend_option  (string)  - QNN backend library path, e.g. /usr/lib/libQnnHtp.so
+//   model_path      (string)  - path to the combined multi-graph .bin file
+//   graph_name_0    (string)  - name of the first graph in the context binary
+//   graph_name_1    (string)  - name of the second graph in the context binary
+class QrbRosSharedInferenceNode : public rclcpp::Node
+{
+public:
+  explicit QrbRosSharedInferenceNode(const rclcpp::NodeOptions & options);
+  ~QrbRosSharedInferenceNode() = default;
+
+private:
+  std::unique_ptr<qrb::inference_mgr::QrbSharedContextLoader> loader_{ nullptr };
+  std::vector<std::unique_ptr<qrb::inference_mgr::QrbInferenceManager>> graph_mgrs_;
+  std::vector<rclcpp::Subscription<custom_msg::TensorList>::SharedPtr> subs_;
+  std::vector<rclcpp::Publisher<custom_msg::TensorList>::SharedPtr> pubs_;
+
+  void graph_callback(custom_msg::TensorList::ConstSharedPtr msg, std::size_t idx);
+  void publish_result(std::size_t idx, const custom_msg::TensorList & input_msg);
+};
+
+}  // namespace qrb_ros::nn_inference
+
+#endif

--- a/qrb_ros_nn_inference/src/qrb_ros_inference_node.cpp
+++ b/qrb_ros_nn_inference/src/qrb_ros_inference_node.cpp
@@ -42,6 +42,7 @@ void QrbRosInferenceNode::subscription_callback(const custom_msg::TensorList & m
 
   const auto input_tensor = (msg.tensor_list)[0];
 
+#ifdef QRB_TENSOR_HAS_DMABUF
   if (input_tensor.dmabuf_fd >= 0 && input_tensor.dmabuf_size > 0) {
     if (false == this->qrb_inference_mgr_->inference_execute_dmabuf(input_tensor.dmabuf_fd,
                      input_tensor.dmabuf_size, input_tensor.dmabuf_offset)) {
@@ -54,6 +55,12 @@ void QrbRosInferenceNode::subscription_callback(const custom_msg::TensorList & m
       rclcpp::shutdown();
     }
   }
+#else
+  if (false == this->qrb_inference_mgr_->inference_execute(input_tensor.data)) {
+    RCLCPP_ERROR(this->get_logger(), "Inference execute fail!");
+    rclcpp::shutdown();
+  }
+#endif
 
   RCLCPP_INFO(this->get_logger(), "Inference execute successfully!");
 
@@ -75,6 +82,7 @@ void QrbRosInferenceNode::publish_msg(custom_msg::TensorList pub_tensors)
     tensor.name = rt.output_tensor_name;
     tensor.shape = rt.output_tensor_shape;
 
+#ifdef QRB_TENSOR_HAS_DMABUF
     if (rt.output_dmabuf_fd >= 0 && rt.output_dmabuf_size > 0) {
       tensor.dmabuf_fd = rt.output_dmabuf_fd;
       tensor.dmabuf_size = rt.output_dmabuf_size;
@@ -82,6 +90,9 @@ void QrbRosInferenceNode::publish_msg(custom_msg::TensorList pub_tensors)
       tensor.dmabuf_ptr = rt.output_dmabuf_ptr;
     } else
       tensor.data = std::move(rt.output_tensor_data);
+#else
+    tensor.data = std::move(rt.output_tensor_data);
+#endif
 
     pub_tensors.tensor_list.emplace_back(std::move(tensor));
   }

--- a/qrb_ros_nn_inference/src/qrb_ros_shared_inference_node.cpp
+++ b/qrb_ros_nn_inference/src/qrb_ros_shared_inference_node.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+
+#include "qrb_ros_nn_inference/qrb_ros_shared_inference_node.hpp"
+
+#include <chrono>
+#include <functional>
+#include <string>
+
+namespace qrb_ros::nn_inference
+{
+
+QrbRosSharedInferenceNode::QrbRosSharedInferenceNode(const rclcpp::NodeOptions & options)
+: Node("qrb_ros_shared_inference_node", options)
+{
+  const std::string backend_option = this->declare_parameter("backend_option", "");
+  const std::string model_path = this->declare_parameter("model_path", "");
+  const std::string graph_name_0 = this->declare_parameter("graph_name_0", "");
+  const std::string graph_name_1 = this->declare_parameter("graph_name_1", "");
+
+  if (model_path.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "model_path parameter is required");
+    rclcpp::shutdown();
+    return;
+  }
+
+  const std::vector<std::string> graph_names = { graph_name_0, graph_name_1 };
+
+  for (const auto & name : graph_names) {
+    if (name.empty()) {
+      RCLCPP_ERROR(this->get_logger(),
+          "graph_name_0 and graph_name_1 parameters are required");
+      rclcpp::shutdown();
+      return;
+    }
+  }
+
+  // Load the combined context binary once.
+  try {
+    loader_ = std::make_unique<qrb::inference_mgr::QrbSharedContextLoader>(
+        model_path, backend_option);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to load shared context: %s", e.what());
+    rclcpp::shutdown();
+    return;
+  }
+
+  // Create one QrbInferenceManager per graph, one pub/sub pair per graph.
+  for (std::size_t i = 0; i < graph_names.size(); ++i) {
+    try {
+      graph_mgrs_.push_back(loader_->make_graph_manager(graph_names[i]));
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(this->get_logger(),
+          "Failed to create graph manager for '%s': %s", graph_names[i].c_str(), e.what());
+      rclcpp::shutdown();
+      return;
+    }
+
+    // Each subscription gets its own Reentrant callback group so both can fire concurrently
+    // under component_container_mt.
+    auto cb_group = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+
+    rclcpp::SubscriptionOptions sub_opts;
+    sub_opts.callback_group = cb_group;
+    sub_opts.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
+
+    const std::string in_topic = "qrb_inference_input_tensor_" + std::to_string(i);
+    const std::string out_topic = "qrb_inference_output_tensor_" + std::to_string(i);
+
+    rclcpp::PublisherOptions pub_opts;
+    pub_opts.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
+
+    pubs_.push_back(
+        this->create_publisher<custom_msg::TensorList>(out_topic, 10, pub_opts));
+
+    subs_.push_back(
+        this->create_subscription<custom_msg::TensorList>(
+            in_topic, 10,
+            [this, i](custom_msg::TensorList::ConstSharedPtr msg) {
+              this->graph_callback(msg, i);
+            },
+            sub_opts));
+
+    RCLCPP_INFO(this->get_logger(),
+        "Graph %zu ('%s'): sub=%s pub=%s",
+        i, graph_names[i].c_str(), in_topic.c_str(), out_topic.c_str());
+  }
+
+  RCLCPP_INFO(this->get_logger(),
+      "QrbRosSharedInferenceNode ready: %zu graphs loaded from %s",
+      graph_names.size(), model_path.c_str());
+}
+
+void QrbRosSharedInferenceNode::graph_callback(
+    custom_msg::TensorList::ConstSharedPtr msg, std::size_t idx)
+{
+  auto t0 = std::chrono::steady_clock::now();
+
+  if (msg->tensor_list.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "Graph %zu: empty tensor list", idx);
+    return;
+  }
+
+  const auto & input_tensor = msg->tensor_list[0];
+
+  bool ok = false;
+#ifdef QRB_TENSOR_HAS_DMABUF
+  if (input_tensor.dmabuf_fd >= 0 && input_tensor.dmabuf_size > 0) {
+    ok = graph_mgrs_[idx]->inference_execute_dmabuf(
+        input_tensor.dmabuf_fd, input_tensor.dmabuf_size, input_tensor.dmabuf_offset);
+  } else {
+    ok = graph_mgrs_[idx]->inference_execute(input_tensor.data);
+  }
+#else
+  ok = graph_mgrs_[idx]->inference_execute(input_tensor.data);
+#endif
+
+  auto t1 = std::chrono::steady_clock::now();
+  double exec_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+  if (!ok) {
+    RCLCPP_ERROR(this->get_logger(), "Graph %zu: inference_execute failed (%.2fms)", idx, exec_ms);
+    return;
+  }
+
+  RCLCPP_INFO(this->get_logger(), "Graph %zu: execute=%.2fms data_size=%zu",
+      idx, exec_ms, input_tensor.data.size());
+
+  publish_result(idx, *msg);
+}
+
+void QrbRosSharedInferenceNode::publish_result(
+    std::size_t idx, const custom_msg::TensorList & input_msg)
+{
+  const auto result_tensors = graph_mgrs_[idx]->get_output_tensors();
+
+  custom_msg::TensorList pub_msg;
+  pub_msg.header = input_msg.header;
+
+  for (auto rt : result_tensors) {
+    custom_msg::Tensor tensor;
+    tensor.data_type = rt.data_type;
+    tensor.name = rt.output_tensor_name;
+    tensor.shape = rt.output_tensor_shape;
+
+#ifdef QRB_TENSOR_HAS_DMABUF
+    if (rt.output_dmabuf_fd >= 0 && rt.output_dmabuf_size > 0) {
+      tensor.dmabuf_fd = rt.output_dmabuf_fd;
+      tensor.dmabuf_size = rt.output_dmabuf_size;
+      tensor.dmabuf_offset = rt.output_dmabuf_offset;
+      tensor.dmabuf_ptr = rt.output_dmabuf_ptr;
+    } else {
+      tensor.data = std::move(rt.output_tensor_data);
+    }
+#else
+    tensor.data = std::move(rt.output_tensor_data);
+#endif
+
+    pub_msg.tensor_list.emplace_back(std::move(tensor));
+  }
+
+  RCLCPP_DEBUG(this->get_logger(), "Graph %zu: publishing %zu output tensors",
+      idx, pub_msg.tensor_list.size());
+  pubs_[idx]->publish(std::move(pub_msg));
+}
+
+}  // namespace qrb_ros::nn_inference
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(qrb_ros::nn_inference::QrbRosSharedInferenceNode)


### PR DESCRIPTION
## Description

Adds `QrbRosSharedInferenceNode`, a composable node that loads a single multi-graph QNN context binary once and exposes one input/output tensor topic pair per graph (`qrb_inference_input_tensor_N` / `qrb_inference_output_tensor_N`). This lets multiple models compiled into one merged/weight-shared context binary (e.g. MiDaS + YOLO11n-seg) run without each needing its own backend/device/context.

**qrb_inference_manager:**
- `QrbSharedContextLoader`: owns the backend/device/context for the lifetime of all graphs; `make_graph_manager(name)` vends a `QrbInferenceManager` that borrows the shared context and only retrieves its own graph.
- `QnnInference` gains a shared-context constructor (borrows context + interface, does not own their lifetime) alongside the existing standalone constructor.
- `QnnInference::inference_execute_ptr()`: zero-copy variant that passes the caller's buffer pointer directly to QNN instead of copying into an intermediate `std::vector` first.
- Collapsed `copy_graph_info_v1/v2/v3` into a single template using a pointer-to-member non-type template parameter, removing duplicated loop bodies.

**qrb_ros_nn_inference:**
- `QrbRosSharedInferenceNode`: one `graph_name_N` parameter + tensor topic pair per graph in the shared context binary.
- Guarded the `dmabuf_fd` tensor field behind a compile-time `QRB_TENSOR_HAS_DMABUF` check (`CheckCXXSourceCompiles` against the installed `qrb_ros_tensor_list_msgs`), since older message versions don't have the `dmabuf_fd`/`dmabuf_size`/`dmabuf_offset`/`dmabuf_ptr` fields. `QrbRosInferenceNode` falls back to `inference_execute()` with the plain byte vector when the fields aren't present.

Also updated the README with the new node's parameters/topics and added a CHANGELOG entry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested on a Qualcomm Dragonwing IQ-9075 EVK with QAIRT SDK 2.46, using a merged multi-graph context binary (MiDaS depth estimation + YOLO11n-seg). Verified both graphs execute correctly from a single shared backend/device/context and publish results on their respective per-graph topics, via a companion sample/launch setup in `qrb_ros_examples` (PR link to follow once opened).

- [x] Ran the shared-context node against a real two-graph context binary on-device and confirmed correct inference output for both graphs
- [ ] Automated unit tests (none added yet for this feature)

**Test Configuration**:
* OS version: Qualcomm Ubuntu (Jazzy)
* Hardware: Qualcomm Dragonwing™ IQ-9075 EVK
* SDK: QAIRT 2.46

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
